### PR TITLE
Updated licenseUrl of typescript

### DIFF
--- a/LICENSES.json
+++ b/LICENSES.json
@@ -14,7 +14,7 @@
     "typescript@3.9.10": {
         "licenses": "Apache-2.0",
         "repository": "https://github.com/Microsoft/TypeScript",
-        "licenseUrl": "https://github.com/Microsoft/TypeScript/raw/master/LICENSE.txt",
+        "licenseUrl": "https://github.com/Microsoft/TypeScript/raw/main/LICENSE.txt",
         "parents": "@brightlayer-ui/cli"
     }
 }


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes #148 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

-Updated licenseUrl for typescript
https://github.com/Microsoft/TypeScript/raw/main/LICENSE.txt

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)
<img width="1792" alt="Screenshot 2023-01-11 at 2 56 30 PM" src="https://user-images.githubusercontent.com/120575281/211768568-4e57d905-f8a4-4929-97d9-26323d529475.png">

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:
- Clone the repository
- Open LICENSES.json
- Click on licenseUrl of typescript / open in browser

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
