### PR TITLE
Fix jest config issue with react native projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Added new Seed UI template for react framework.
 
+### Fixed
+
+- Issue where the latest react-native project generation would fail to update the jest configuration.
+
 ## v4.0.0 (July 14, 2023)
 
 ### Changed

--- a/src/extensions/pxblue-extensions.ts
+++ b/src/extensions/pxblue-extensions.ts
@@ -13,7 +13,6 @@ import {
     PRETTIER_SCRIPTS,
     NPM7_PREFIX,
 } from '../constants';
-import { JEST } from '../constants/jest';
 import {
     updateScripts,
     updateBrowsersListFile,
@@ -482,11 +481,19 @@ module.exports = (toolbox: GluegunToolbox): void => {
         packageJSON.scripts.test = 'jest';
         filesystem.write(`${folder}/package.json`, packageJSON, { jsonIndent: 4 });
 
+        const JestConfig = `module.exports = {
+    preset: 'react-native',
+    transformIgnorePatterns: ['node_modules/(@react-native-community|react-navigation|@react-navigation/.*)'],
+    setupFiles: ['./jestSetupFile.js', './node_modules/react-native-gesture-handler/jestSetup.js'],
+    moduleNameMapper: {
+        '\\\\.svg': '<rootDir>/__mocks__/svgMock.js',
+        '.+\\\\.(css|styl|less|sass|scss|png|jpg|ttf|woff|woff2)$': 'jest-transform-stub',
+        '\\\\.(css|less)$': 'identity-obj-proxy',
+    },
+};`;
         // Configure Jest
-        packageJSON.jest.transformIgnorePatterns = JEST.TRANSFORM_IGNORE_PATTERNS;
-        packageJSON.jest.setupFiles = JEST.SETUP_FILES;
-        packageJSON.jest.moduleNameMapper = JEST.MODULE_NAME_MAPPER;
-        filesystem.write(`${folder}/package.json`, packageJSON, { jsonIndent: 4 });
+        // @TODO: fix this... write to jest.config.js instead of package json
+        filesystem.write(`${folder}/jest.config.js`, JestConfig);
 
         // Link native modules
         const command = `cd ${folder} && ${NPM7_PREFIX} && npx react-native-asset`;


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes issue where the jest configuration wasn't being copied over properly due to the underlying file structure change in the react-native cli.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Fix jest config issue with react native projects
-
-

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

-

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- clone project and run `yarn build && yarn link`
- generate a new react native project with `blui new`
- test all 3 templates for react native and ensure that the projects run and the jest.config.js file looks like this:
```
module.exports = {
    preset: 'react-native',
    transformIgnorePatterns: ['node_modules/(@react-native-community|react-navigation|@react-navigation/.*)'],
    setupFiles: ['./jestSetupFile.js', './node_modules/react-native-gesture-handler/jestSetup.js'],
    moduleNameMapper: {
        '\\.svg': '<rootDir>/__mocks__/svgMock.js',
        '.+\\.(css|styl|less|sass|scss|png|jpg|ttf|woff|woff2)$': 'jest-transform-stub',
        '\\.(css|less)$': 'identity-obj-proxy',
    },
};
```

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
